### PR TITLE
adding codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @sourceallies/sai-library


### PR DESCRIPTION
This will automatically tag the team on any open PRs: https://help.github.com/en/articles/about-code-owners
